### PR TITLE
Enhancement/paginate through transaction data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'leaflet-awesome-markers-rails', '~> 2.0'
 gem 'uglifier'
+gem 'will_paginate', '~> 3.1.0'
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.1.6)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
@@ -303,6 +304,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier
+  will_paginate (~> 3.1.0)
 
 BUNDLED WITH
    1.16.1

--- a/app/controllers/concerns/transaction_search_concern.rb
+++ b/app/controllers/concerns/transaction_search_concern.rb
@@ -16,6 +16,5 @@ module TransactionSearchConcern
       .concat(contributions)
       .sort_by(&:last)
       .map(&:first)
-      .slice(0,50)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,5 @@
 require 'geocoder'
+require 'will_paginate/array'
 
 class SearchController < ApplicationController
   include LocationSearchConcern
@@ -29,7 +30,9 @@ class SearchController < ApplicationController
 
       transactions = get_transactions(@result_lat, @result_lng, 5)
 
-      @markers = get_markers(transactions)
+      @transactions_count = transactions.count
+
+      @markers = get_markers(transactions).paginate(page: params[:page], per_page: 50)
       @bounds = get_bounds
       @filers = get_filers(transactions)
 

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -7,6 +7,9 @@
             %span.fas.fa-money-bill-alt
             Nearby Transactions
             ="(#{@markers.count} found)" if @markers
+            %br
+            = page_entries_info(@markers, { model: 'Transactions' })
+            = will_paginate @markers, page_links: false
       #collapseOne.panel-collapse.collapse
         .panel-body
           %table.table


### PR DESCRIPTION
This should be put on top of of `add-id-to-icon`. The `map` function must be explicitly called (rather than `Document.ready`) for this to all work.