### PR TITLE
Replace font awesome .js with .css as quick resolution to bug

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %meta{content: "width=device-width, initial-scale=1, shrink-to-fit=no", name: "viewport"}
     %script{src: "//maps.google.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}" }
     %link{:href => "https://fonts.googleapis.com/css?family=Fjalla+One", :rel => "stylesheet"}/
-    %script{:defer => "defer", :src => "https://use.fontawesome.com/releases/v5.0.6/js/all.js"}
+    %link{:href => "https://use.fontawesome.com/releases/v5.0.6/css/all.css", :rel => "stylesheet"}/
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag 'application'
     = csrf_meta_tags


### PR DESCRIPTION
This resolves issue where loading new pagination results made all the font awesome icons disappear