### PR TITLE
Add map view for filer page and massage lat/long in transaction models

### DIFF
--- a/app/controllers/filers_controller.rb
+++ b/app/controllers/filers_controller.rb
@@ -1,6 +1,10 @@
-class FilersController < ApplicationController
+require 'geocoder'
 
-  before_action :get_filer, only: :show
+class FilersController < ApplicationController
+  include LocationSearchConcern
+  include TransactionSearchConcern
+
+  before_action :get_filer, :get_markers, only: :show
 
   def index
   end
@@ -11,6 +15,44 @@ class FilersController < ApplicationController
   def get_filer
     @filer = Filer.find(params[:id])
     @transactions = @filer.transactions
+
+    @result = @filer.filer_zipcode
+    @result_lat = @filer.filer_location_1_lat
+    @result_lng = @filer.filer_location_1_long
+    @transactions_count = @transactions.count
+
+    @markers = get_markers()
+    @bounds = get_bounds
+    @filers = get_filers(@transactions)
+  end
+
+  private
+
+  def get_markers()
+    @transactions.map do |transaction|
+      transaction_type = transaction.class.name.downcase
+      {
+        latlng: transaction.lat_lng,
+        popup: transaction.description,
+        id: "#{transaction_type}-#{transaction.id}",
+        filer_id: "filer_id-#{transaction.filer_id}",
+        marker_type: transaction_type
+      }
+    end
+  end
+
+  def get_bounds
+    markers = @markers.reject{ |marker| marker[:latlng].count != 2 }
+    points = markers.map{ |marker| marker[:latlng] }
+    lats = points.map(&:first)
+    lngs = points.map(&:last)
+    [[lats.min, lngs.min], [lats.max, lngs.max]]
+
+  end
+
+  def get_filers(transactions)
+    transactions.map do |transaction|
+      transaction.filer
+    end
   end
 end
-

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -24,7 +24,37 @@ class Contribution < ApplicationRecord
 
   def lat_lng
     lat_lng = []
-    lat_lng.push(contributor_location_1_lat).push(contributor_location_1_long)
+
+    # Check as sometimes lat/long is null in DB
+    if !contributor_location_1_lat.to_s.empty?
+      lat=contributor_location_1_lat
+    elsif !contributor_location_2_lat.to_s.empty?
+      lat=contributor_location_2_lat
+    elsif !employer_location_1_lat.to_s.empty?
+      lat=employer_location_1_lat
+    elsif !employer_location_2_lat.to_s.empty?
+      lat=employer_location_2_lat
+    elsif !filer.filer_location_1_lat.to_s.empty?
+      lat=filer.filer_location_1_lat
+    else
+      lat=filer.filer_location_2_lat
+    end
+
+    if !contributor_location_1_long.to_s.empty?
+      long=contributor_location_1_long
+    elsif !contributor_location_2_long.to_s.empty?
+      long=contributor_location_2_long
+    elsif !employer_location_1_long.to_s.empty?
+      long=employer_location_1_long
+    elsif !employer_location_2_long.to_s.empty?
+      long=employer_location_2_long
+    elsif !filer.filer_location_1_long.to_s.empty?
+      long=filer.filer_location_1_long
+    else
+      long=filer.filer_location_2_long
+    end
+
+    lat_lng.push(lat).push(long)
   end
 
   def description

--- a/app/models/debt.rb
+++ b/app/models/debt.rb
@@ -70,6 +70,34 @@ class Debt < ApplicationRecord
     lat_lng.push(debt_reporting_location_1_lat).push(debt_reporting_location_1_long)
   end
 
+  def lat_lng
+    lat_lng = []
+
+    # Check as sometimes lat/long is null in DB
+    if !debt_reporting_location_1_lat.to_s.empty?
+      lat=debt_reporting_location_1_lat
+    elsif !debt_reporting_location_2_lat.to_s.empty?
+      lat=debt_reporting_location_2_lat
+    else
+      lat=filer.filer_location_1_lat
+    end
+
+    if !debt_reporting_location_1_long.to_s.empty?
+      long=debt_reporting_location_1_long
+    elsif !debt_reporting_location_2_long.to_s.empty?
+      long=debt_reporting_location_2_long
+    else
+      long=filer.filer_location_1_long
+    end
+
+    lat_lng.push(lat).push(long)
+  end
+
+
+
+
+
+
   def description
     "<em>#{debt_accrual_date}</em><br />
     <strong>Debt</strong> $#{sprintf('%.2f', debt_amount)} <br />

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -25,7 +25,21 @@ class Expense < ApplicationRecord
 
   def lat_lng
     lat_lng = []
-    lat_lng.push(expense_location_1_lat).push(expense_location_1_long)
+
+    # Check as sometimes lat/long is null in DB
+    unless expense_location_1_lat.to_s.empty?
+      lat=expense_location_1_lat
+    else
+      lat=expense_location_2_lat
+    end
+
+    unless expense_location_1_long.to_s.empty?
+      long=expense_location_1_long
+    else
+      long=expense_location_2_long
+    end
+
+    lat_lng.push(lat).push(long)
   end
 
   def description

--- a/app/models/filer.rb
+++ b/app/models/filer.rb
@@ -34,4 +34,24 @@ class Filer < ApplicationRecord
       .concat(contributions)
   end
 
+  def lat_lng
+    lat_lng = []
+
+    # Check as sometimes lat/long is null in DB
+    unless filer_location_1_lat.to_s.empty?
+      lat=filer_location_1_lat
+    else
+      lat=filer_location_2_lat
+    end
+
+    unless filer_location_1_long.to_s.empty?
+      long=filer_location_1_long
+    else
+      long=filer_location_2_long
+    end
+
+    lat_lng.push(lat).push(long)
+  end
+
+
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -25,7 +25,23 @@ class Receipt < ApplicationRecord
 
   def lat_lng
     lat_lng = []
-    lat_lng.push(receipt_location_1_lat).push(receipt_location_1_long)
+
+    # Check as sometimes lat/long is null in DB
+    if !receipt_location_1_lat.to_s.empty? && !receipt_location_1_long.to_s.empty?
+      lat=receipt_location_1_lat
+      long=receipt_location_1_long
+    elsif !receipt_location_2_lat.to_s.empty? && !receipt_location_2_long.to_s.empty?
+      lat=receipt_location_2_lat
+      long=receipt_location_2_long
+    elsif !filer.filer_location_1_lat.to_s.empty? && !filer.filer_location_1_long.to_s.empty?
+      lat=filer.filer_location_1_lat
+      long=filer.filer_location_2_long
+    else
+      lat=filer.filer_location_2_lat
+      long=filer.filer_locatoin_2_long
+    end
+
+    lat_lng.push(lat).push(long)
   end
 
   def description

--- a/app/views/filers/show.html.haml
+++ b/app/views/filers/show.html.haml
@@ -1,75 +1,88 @@
 = render 'shared/navbar'
 
-.container-fluid
-  .row
-    .col-sm-8
-      %h1
-        Filer Profile
-      %h2
-        = @filer.filer_name
-      %table.table.table-striped
-        %tbody
-          %tr
-            %th
-              Filer Name
-            %td
-              = @filer.filer_name
-            %th
-              Filer ID
-            %td
-              = @filer.filer_id
-          %tr
-            %th
-              Election Year
-            %td
-              = @filer.election_year
-            %th
-              Election Cycle
-            %td
-              = @filer.election_cycle
-          %tr
-            %th
-              Political Party
-            %td
-              = !@filer.party.nil? ? @filer.party : 'Not Reported'
-            %th
-              Filer Office
-            %td
-              = !@filer.office.nil? ? @filer.office : 'Not Reported'
-          %tr
-            %th
-              Filer Address
-            %td
-              = formatted_address(@filer)
-            %th
-              Filer Type
-            %td
-              = @filer.expanded_filer_type
-          %tr
-            %th
-              Beginning Balance
-            %td
-              = number_to_currency(@filer.beginning_balance)
-            %th
-              Monetary Contributions
-            %td
-              = number_to_currency(@filer.monetary)
-          %tr
-            %th
-              In-Kind Contributions
-            %td
-              = number_to_currency(@filer.in_kind)
-            %th
-            %td
+:javascript
+  initialCenter = #{@filer.lat_lng}
+  markerData = #{@markers.to_json.html_safe}
+  bounds = #{@bounds}
 
-    .col-sm-4
-  .row
+.row
+  .col-sm-8
     %h1
-      Filer Transactions
+      Filer Profile
+    %h2
+      = @filer.filer_name
     %table.table.table-striped
       %tbody
-        - @transactions.map do | transaction |
-          %tr
-            %td
-              = transaction.description.html_safe
+        %tr
+          %th
+            Filer Name
+          %td
+            = @filer.filer_name
+          %th
+            Filer ID
+          %td
+            = @filer.filer_id
+        %tr
+          %th
+            Election Year
+          %td
+            = @filer.election_year
+          %th
+            Election Cycle
+          %td
+            = @filer.election_cycle
+        %tr
+          %th
+            Political Party
+          %td
+            = !@filer.party.nil? ? @filer.party : 'Not Reported'
+          %th
+            Filer Office
+          %td
+            = !@filer.office.nil? ? @filer.office : 'Not Reported'
+        %tr
+          %th
+            Filer Address
+          %td
+            = formatted_address(@filer)
+          %th
+            Filer Type
+          %td
+            = @filer.expanded_filer_type
+        %tr
+          %th
+            Beginning Balance
+          %td
+            = number_to_currency(@filer.beginning_balance)
+          %th
+            Monetary Contributions
+          %td
+            = number_to_currency(@filer.monetary)
+        %tr
+          %th
+            In-Kind Contributions
+          %td
+            = number_to_currency(@filer.in_kind)
+          %th
+          %td
+  .col-sm-4
+    .panel.panel-default
+      .panel-heading
+        Select a marker to see the description
+      .panel-body.panel-map
+        #map
 
+.row
+  %h1
+    Filer Transactions
+  %table.table.table-striped
+    %tbody
+      - @transactions.map do | transaction |
+        %tr
+          %td
+            = transaction.description.html_safe
+
+
+:javascript
+  map = L.map('map').setView(initialCenter, 15)
+  loadMarkers()


### PR DESCRIPTION
Add map to filer page, and for transactions without full location data changed model to return either 1st or 2nd location. If value is still null, return location 1 or 2 for filer. (For example, lot of contributions with no address, so just gives the address of the recipient) 

Still room to make this more elegant and consistent between the different transaction models.